### PR TITLE
#17: Fixed bug where "Never show this again" didn't work right on first-time disclaimer

### DIFF
--- a/Swift Mines/Shared Cross-Platform/Data Structures/AppScreen.swift
+++ b/Swift Mines/Shared Cross-Platform/Data Structures/AppScreen.swift
@@ -41,7 +41,7 @@ public extension AppScreen {
     
     /// The screen to show when the app starts. This takes into account any previous app state.
     static func appropriateStartupScreen() -> AppScreen {
-        if OobeState.shared.shouldShowDisclaimer {
+        if !OobeState.shared.skipFirstTimeDisclaimer {
             return .oobe
         }
         else {

--- a/Swift Mines/Shared Cross-Platform/GUI/SwiftUI/FirstTimeDisclaimerView.swift
+++ b/Swift Mines/Shared Cross-Platform/GUI/SwiftUI/FirstTimeDisclaimerView.swift
@@ -35,8 +35,8 @@ public struct FirstTimeDisclaimerView: View {
             HStack {
                 Spacer()
                 Toggle("Never show this again", isOn: Binding(
-                    get: { !self.overallAppState.oobeState.shouldShowDisclaimer },
-                    set: { self.overallAppState.oobeState.shouldShowDisclaimer = !$0 })
+                    get: { self.overallAppState.oobeState.skipFirstTimeDisclaimer },
+                    set: { self.overallAppState.oobeState.skipFirstTimeDisclaimer = $0 })
                 )
                 NativeButton("Play without \(phrase_secondaryClick)", keyEquivalent: .return) { self.overallAppState.currentScreen = .game }
             }

--- a/Swift Mines/Shared Cross-Platform/Serialization/States/OobeState.swift
+++ b/Swift Mines/Shared Cross-Platform/Serialization/States/OobeState.swift
@@ -15,8 +15,8 @@ import UserDefault
 /// The state of the out-of-the-box experience (first run and after an update)
 public struct OobeState {
         
-    @UserDefault("shouldShowDisclaimer", defaults: .neverShowAgainStates)
-    var shouldShowDisclaimer = true
+    @UserDefault("skipFirstTimeDisclaimer", defaults: .neverShowAgainStates)
+    var skipFirstTimeDisclaimer = false
     
 //    @UserDefault
 //    var mostRecentVersionReleaseNotesSeen: SemVer

--- a/Swift Mines/Swift Mines.xcodeproj/project.pbxproj
+++ b/Swift Mines/Swift Mines.xcodeproj/project.pbxproj
@@ -895,7 +895,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_ASSET_PATHS = "\"Swift Mines for macOS/Preview Content\"";
 				DEVELOPMENT_TEAM = 26V9MK8TGP;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -906,7 +906,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.0.4;
+				MARKETING_VERSION = 1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.benleggiero.Swift-Mines";
 				PRODUCT_NAME = "Swift Mines";
 				SWIFT_VERSION = 5.0;
@@ -921,7 +921,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_ASSET_PATHS = "\"Swift Mines for macOS/Preview Content\"";
 				DEVELOPMENT_TEAM = 26V9MK8TGP;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -932,7 +932,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.0.4;
+				MARKETING_VERSION = 1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.benleggiero.Swift-Mines";
 				PRODUCT_NAME = "Swift Mines";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
If you left that unchecked, meaning you wanted to see it again, then if you moved the window, then next time you start the app, the disclaimer won't show. This is because UserDefaults defaults `Bool`s to `false`. Might try to change the Swift Package I'm using to circumvent this. In the meantime, I just changed it from "should show" to "should skip".