### PR TITLE
One more edit to the wording.. 😩

### DIFF
--- a/Swift Mines/Shared Cross-Platform/GUI/SwiftUI/FirstTimeDisclaimerView.swift
+++ b/Swift Mines/Shared Cross-Platform/GUI/SwiftUI/FirstTimeDisclaimerView.swift
@@ -27,7 +27,7 @@ public struct FirstTimeDisclaimerView: View {
                 .fixedSize()
 
             Text("""
-                This was written entirely in Swift, using the new SwiftUI platform! Since SwiftUI is in its early stages, SwiftUI has a few odd quirks. One that you'll notice is that it does not yet support \(phrase_secondaryClicking). Instead, to place a flag, you can hold Control and click, or perform a long-click. Once SwiftUI supports \(phrase_secondaryClicking), this game will be updated to include that.
+                This was written entirely in Swift, using the new SwiftUI platform! Since SwiftUI does not yet support \(phrase_secondaryClicking), to place a flag, you can hold Control and click, or perform a long-click. Once SwiftUI supports \(phrase_secondaryClicking), this game will be updated to include that.
                 
                 Have fun!
                 """)

--- a/Swift Mines/Swift Mines.xcodeproj/project.pbxproj
+++ b/Swift Mines/Swift Mines.xcodeproj/project.pbxproj
@@ -895,7 +895,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_ASSET_PATHS = "\"Swift Mines for macOS/Preview Content\"";
 				DEVELOPMENT_TEAM = 26V9MK8TGP;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -906,7 +906,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.benleggiero.Swift-Mines";
 				PRODUCT_NAME = "Swift Mines";
 				SWIFT_VERSION = 5.0;
@@ -921,7 +921,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_ASSET_PATHS = "\"Swift Mines for macOS/Preview Content\"";
 				DEVELOPMENT_TEAM = 26V9MK8TGP;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -932,7 +932,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.benleggiero.Swift-Mines";
 				PRODUCT_NAME = "Swift Mines";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
This continues #17.

According to the app reviewer:

> ## Guideline 2.3 - Performance
>
>
> Your application description contains defamatory comments about Apple, Apple products and services, or about a third-party.
>
> ### Next Steps
>
> It would be appropriate to remove “Since SwiftUI is in its early states, SwiftUI has a few odd quirks” from the Disclaimer on launch of app.
> 
> ![A screenshot showing the wording before this pull request](https://user-images.githubusercontent.com/10189808/74684404-06857380-5189-11ea-97d9-a8c6d6174156.png)


My response read:

> Thank you for taking the time to leave such specific feedback. I didn't mean to come of as defamatory; the truth is that SwiftUI does not allow right-clicking, and since there's nothing that I can do about this, I want to be able to inform my users that the traditional Minesweeper paradigm of right-clicking to place a flag is impossible, but that's not something I can fix until SwiftUI allows it. I will try to re-word this disclaimer to better-explain this issue so that it doesn't come off as defamatory to Apple nor myself.
